### PR TITLE
Require repl / don't trigger a launch of a new JVM

### DIFF
--- a/autoload/vim_clojure_highlight.vim
+++ b/autoload/vim_clojure_highlight.vim
@@ -1,31 +1,24 @@
 " vim-clojure-highlight
 
-" By default spawn a Java process as necessary when opening a file
-if !exists('g:vim_clojure_highlight_require_existing_session')
-	let g:vim_clojure_highlight_require_existing_session = 0
-endif
-
 function! vim_clojure_highlight#existing_session()
-	if !g:vim_clojure_highlight_require_existing_session ||
-	\ (exists('g:fireplace_nrepl_sessions') && len(g:fireplace_nrepl_sessions))
-		return 1
-	endif
-	return 0
+	return exists('g:fireplace_nrepl_sessions') && len(g:fireplace_nrepl_sessions)
 endfunction
 
 function! vim_clojure_highlight#require()
-	if vim_clojure_highlight#existing_session() && fireplace#evalparse("(find-ns 'vim-clojure-highlight)") ==# ''
+	if !vim_clojure_highlight#existing_session() | return | endif
+
+	if fireplace#evalparse("(find-ns 'vim-clojure-highlight)") ==# ''
 		let buf = join(readfile(globpath(&runtimepath, 'autoload/vim_clojure_highlight.clj')), "\n")
 		call fireplace#session_eval('(do ' . buf . ')')
 	endif
 endfunction
 
 function! vim_clojure_highlight#syntax_match_references()
+	if !vim_clojure_highlight#existing_session() | return | endif
+
 	try
 		call vim_clojure_highlight#require()
-		if vim_clojure_highlight#existing_session()
-			execute fireplace#evalparse("(vim-clojure-highlight/ns-syntax-command '" . fireplace#ns() . ")")
-		endif
+		execute fireplace#evalparse("(vim-clojure-highlight/ns-syntax-command '" . fireplace#ns() . ")")
 	catch /./
 	endtry
 endfunction


### PR DESCRIPTION
I'm currently using this locally to only carry out highlighting when it has an nrepl to connect to.

Fireplace will happily launch a JVM for you. But in my current work project, that takes ~20 seconds to start hanging the editor in the meantime..!

With this change, I can always open a file instantly, then at some point later launch a repl, then `:e` to get the highlighting.
