### PR TITLE
trivial fix for allowing Vundle to "BundleUpdate"

### DIFF
--- a/plugin/vim_clojure_highlight.vim
+++ b/plugin/vim_clojure_highlight.vim
@@ -9,4 +9,4 @@ augroup vim_clojure_highlight
 	autocmd BufRead,BufNewFile *.clj if g:clojure_highlight_references | call vim_clojure_highlight#syntax_match_references() | endif
 augroup END
 
-command ToggleClojureHighlightReferences let g:clojure_highlight_references = !g:clojure_highlight_references | edit
+command! ToggleClojureHighlightReferences let g:clojure_highlight_references = !g:clojure_highlight_references | edit


### PR DESCRIPTION
Was getting "command already exists" errors during a Vundle "BundleUpdate due Vundle's update mechanism.
