### PR TITLE
Add support for highlighting non-aliased public namespace members.

### DIFF
--- a/autoload/vim_clojure_highlight.clj
+++ b/autoload/vim_clojure_highlight.clj
@@ -67,6 +67,14 @@
             (ns-publics alias-ns)))
     (ns-aliases ns)))
 
+(defn all-ns-refers []
+  (mapcat
+    (fn [current-ns]
+      (mapv
+        #(vector (symbol (str current-ns \/ (first %))) (peek %))
+        (ns-publics current-ns)))
+    (map #(symbol (str %)) (all-ns))))
+
 (defn var-type [v]
   (let [f @v m (meta v)]
     (cond (clojure-core? v) (core-symbol->syntax-group (:name m))
@@ -87,6 +95,7 @@
 (defn ns-syntax-command [ns & opts]
   (let [{:keys [local-vars] :or {local-vars true}} (apply hash-map opts)
         dict (syntax-keyword-dictionary (concat (ns-refers ns)
+                                                (all-ns-refers)
                                                 (aliased-refers ns)
                                                 (when local-vars (ns-publics ns))))]
     (str "let b:clojure_syntax_without_core_keywords = 1 | let b:clojure_syntax_keywords = {" dict "}")))

--- a/autoload/vim_clojure_highlight.vim
+++ b/autoload/vim_clojure_highlight.vim
@@ -5,8 +5,12 @@ function! s:session_exists()
 		return 1
 	endif
 	" Fall through in case we're using a newer version of fireplace.
-	let client = fireplace#client()
-	return has_key(client, 'transport')
+	try
+		let client = fireplace#client()
+		return has_key(client, 'transport')
+	catch /./
+	endtry
+	return 0
 endfunction
 
 function! s:require()

--- a/autoload/vim_clojure_highlight.vim
+++ b/autoload/vim_clojure_highlight.vim
@@ -1,7 +1,8 @@
 " vim-clojure-highlight
 
 function! s:session_exists()
-	return exists('g:fireplace_nrepl_sessions') && len(g:fireplace_nrepl_sessions)
+	let client = fireplace#client()
+	return has_key(client, 'transport')
 endfunction
 
 function! s:require()

--- a/autoload/vim_clojure_highlight.vim
+++ b/autoload/vim_clojure_highlight.vim
@@ -1,13 +1,8 @@
 " vim-clojure-highlight
 
 function! s:session_exists()
-	if exists('g:fireplace_nrepl_sessions') && len(g:fireplace_nrepl_sessions)
-		return 1
-	endif
-	" Fall through in case we're using a newer version of fireplace.
 	try
-		let client = fireplace#client()
-		return has_key(client, 'transport')
+		return fireplace#op_available('eval')
 	catch /./
 	endtry
 	return 0

--- a/autoload/vim_clojure_highlight.vim
+++ b/autoload/vim_clojure_highlight.vim
@@ -1,6 +1,10 @@
 " vim-clojure-highlight
 
 function! s:session_exists()
+	if exists('g:fireplace_nrepl_sessions') && len(g:fireplace_nrepl_sessions)
+		return 1
+	endif
+	" Fall through in case we're using a newer version of fireplace.
 	let client = fireplace#client()
 	return has_key(client, 'transport')
 endfunction

--- a/autoload/vim_clojure_highlight.vim
+++ b/autoload/vim_clojure_highlight.vim
@@ -9,7 +9,8 @@ function! s:session_exists()
 endfunction
 
 function! s:require()
-	if fireplace#evalparse("(find-ns 'vim-clojure-highlight)") ==# ''
+	"echo(fireplace#evalparse("(find-ns 'vim-clojure-highlight)") != 'vim-clojure-highlight')
+	if fireplace#evalparse("(find-ns 'vim-clojure-highlight)") != 'vim-clojure-highlight'
 		let buf = join(readfile(globpath(&runtimepath, 'autoload/vim_clojure_highlight.clj')), "\n")
 		call fireplace#session_eval('(do ' . buf . ')')
 	endif


### PR DESCRIPTION
For example, allows full names like `clojure.core/conj` to get highlighted based on namespaces described in `(all-ns)`.